### PR TITLE
Fix invalid namespace reference

### DIFF
--- a/tarstats.py
+++ b/tarstats.py
@@ -187,7 +187,7 @@ def tarstats(filenames: List[str], json: bool, totals: bool):
         try:
             stats = tarstat(name)
         except FileNotFoundError as e:
-            print(f"Can't read '{name}': {e}", file=sys.stderr)
+            print(f"Can't read '{name}': {e}", file=stderr)
             exit(1)
 
         # Print intermediate results


### PR DESCRIPTION
Fixes:

```
→ ./tarstats.py NONEXISTENT
Traceback (most recent call last):
  File "/home/juergen/ghq/github.com/isotopp/tarstats/./tarstats.py", line 188, in tarstats
    stats = tarstat(name)
  File "/home/juergen/ghq/github.com/isotopp/tarstats/./tarstats.py", line 143, in tarstat
    with tarfile.open(filename, "r") as t:
  File "/usr/lib/python3.10/tarfile.py", line 1613, in open
    return func(name, "r", fileobj, **kwargs)
  File "/usr/lib/python3.10/tarfile.py", line 1679, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
  File "/usr/lib/python3.10/gzip.py", line 174, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'NONEXISTENT'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/juergen/ghq/github.com/isotopp/tarstats/./tarstats.py", line 227, in <module>
    main()
  File "/home/juergen/ghq/github.com/isotopp/tarstats/./tarstats.py", line 223, in main
    tarstats(args.tarfile, args.json, args.totals)
  File "/home/juergen/ghq/github.com/isotopp/tarstats/./tarstats.py", line 190, in tarstats
    print(f"Can't read '{name}': {e}", file=sys.stderr)
NameError: name 'sys' is not defined

```